### PR TITLE
Fix sequential number generation

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,9 +4,15 @@ const sightWords = [
     "have", "from", "or", "one", "by", "not", "but", "all", "we", "can"
 ];
 
-function incrementNumber(element) {
-    // Generate a random number between 1 and 100
-    return Math.floor(Math.random() * 100) + 1;
+let currentNumber = 0;
+
+function incrementNumber() {
+    // Increment number from 1 to 100 then wrap back to 1
+    currentNumber += 1;
+    if (currentNumber > 100) {
+        currentNumber = 1;
+    }
+    return currentNumber;
 }
 
 function generateLetter() {
@@ -23,7 +29,7 @@ function generateLetter() {
         const randomWord = sightWords[Math.floor(Math.random() * sightWords.length)];
         letterElement.textContent = randomWord;
     } else {
-        letterElement.innerText = incrementNumber(letterElement);
+        letterElement.innerText = incrementNumber();
     }
 }
 


### PR DESCRIPTION
## Summary
- make `incrementNumber` actually increment sequential numbers instead of returning random numbers
- remove unused parameter when calling `incrementNumber`

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848be01f5248324b558fae7357552d4