### PR TITLE
Fix number display bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,11 +25,11 @@ function generateLetter() {
         letterElement.textContent = randomLetter.toUpperCase();
     } else if(caseType === 'lowercase') {
         letterElement.textContent = randomLetter;
+    } else if(caseType === 'numbers') {
+        letterElement.textContent = incrementNumber();
     } else if(caseType === 'sightWords') {
         const randomWord = sightWords[Math.floor(Math.random() * sightWords.length)];
         letterElement.textContent = randomWord;
-    } else {
-        letterElement.innerText = incrementNumber();
     }
 }
 


### PR DESCRIPTION
## Summary
- display sequential numbers using `textContent`
- support dedicated `numbers` case

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848bf72784083249392799f498df6e1