### PR TITLE
Add early reading word categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # toddlerLearning
-A simple letter guessing game that shows uppercase and lowercase letters, numbers, and kindergarten sight words
+A simple letter guessing game that shows uppercase and lowercase letters, numbers, kindergarten sight words and basic three and four letter words for early readers.
+
+## Usage
+
+Open `index.html` in a modern web browser. Use the dropdown to choose the category:
+
+- **Lowercase/Uppercase** – random letters
+- **Numbers** – counts from 1 to 100
+- **Kindergarten sight words** – common sight words
+- **3-letter words** – simple words like `cat`, `dog`, etc.
+- **4-letter words** – slightly longer words like `tree` or `book`
+
+Click **Next** to show a new entry each time.
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,9 @@
             <option value="lowercase">Lowercase</option>
             <option value="uppercase">Uppercase</option>
             <option value="numbers">Numbers</option>
-<option value="sightWords">Kindergarten sight words</option>
+            <option value="sightWords">Kindergarten sight words</option>
+            <option value="threeLetterWords">3-letter words</option>
+            <option value="fourLetterWords">4-letter words</option>
         </select>
     </div>
     <div id="letter"></div>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,17 @@ const sightWords = [
     "have", "from", "or", "one", "by", "not", "but", "all", "we", "can"
 ];
 
+// Simple three and four letter word lists for early reading practice
+const threeLetterWords = [
+    "cat", "dog", "sun", "car", "bus",
+    "hat", "cup", "pig", "bed", "run"
+];
+
+const fourLetterWords = [
+    "tree", "book", "frog", "play", "jump",
+    "rain", "fish", "milk", "time", "ball"
+];
+
 let currentNumber = 0;
 
 function incrementNumber() {
@@ -30,6 +41,12 @@ function generateLetter() {
     } else if(caseType === 'sightWords') {
         const randomWord = sightWords[Math.floor(Math.random() * sightWords.length)];
         letterElement.textContent = randomWord;
+    } else if(caseType === 'threeLetterWords') {
+        const randomWord = threeLetterWords[Math.floor(Math.random() * threeLetterWords.length)];
+        letterElement.textContent = randomWord;
+    } else if(caseType === 'fourLetterWords') {
+        const randomWord = fourLetterWords[Math.floor(Math.random() * fourLetterWords.length)];
+        letterElement.textContent = randomWord;
     }
 }
 
@@ -42,5 +59,9 @@ if (typeof document !== 'undefined') {
 
 // Export functions for testing environments like Node.js
 if (typeof module !== 'undefined') {
-    module.exports = { incrementNumber };
+    module.exports = {
+        incrementNumber,
+        threeLetterWords,
+        fourLetterWords
+    };
 }

--- a/script.test.js
+++ b/script.test.js
@@ -1,11 +1,23 @@
 const assert = require('assert');
-const { incrementNumber } = require('./script');
+const { incrementNumber, threeLetterWords, fourLetterWords } = require('./script');
 
 // Ensure multiple invocations stay within range 1-100
 for (let i = 0; i < 1000; i++) {
   const result = incrementNumber();
   assert.strictEqual(Number.isInteger(result), true, 'Result should be integer');
   assert.ok(result >= 1 && result <= 100, `Value ${result} out of range`);
+}
+
+// Ensure three-letter and four-letter word lists contain the expected word lengths
+assert.ok(threeLetterWords.length > 0, 'threeLetterWords should not be empty');
+assert.ok(fourLetterWords.length > 0, 'fourLetterWords should not be empty');
+
+for (const word of threeLetterWords) {
+  assert.strictEqual(word.length, 3, `Word ${word} is not three letters`);
+}
+
+for (const word of fourLetterWords) {
+  assert.strictEqual(word.length, 4, `Word ${word} is not four letters`);
 }
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- teach 3- and 4-letter words in the learning app
- let the page select the new categories
- export the word lists for testing
- verify lists via new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c1f5031883249d24e79112d24142