### PR TITLE
Show board briefly in memory game

### DIFF
--- a/memory.html
+++ b/memory.html
@@ -17,18 +17,18 @@
         }
         #board {
             display: grid;
-            grid-template-columns: repeat(3, 100px);
-            grid-template-rows: repeat(2, 100px);
+            grid-template-columns: repeat(3, 120px);
+            grid-template-rows: repeat(2, 120px);
             gap: 10px;
         }
         .cell {
-            width: 100px;
-            height: 100px;
+            width: 120px;
+            height: 120px;
             display: flex;
             align-items: center;
             justify-content: center;
             background: #ddd;
-            font-size: 48px;
+            font-size: 56px;
             cursor: pointer;
             user-select: none;
         }

--- a/memory.js
+++ b/memory.js
@@ -14,13 +14,23 @@ let lockBoard = false;
 function setupBoard() {
     const board = document.getElementById('board');
     const shuffled = shuffle(shapes.slice());
+    lockBoard = true;
     shuffled.forEach(shape => {
         const cell = document.createElement('div');
         cell.className = 'cell';
         cell.dataset.shape = shape;
+        cell.textContent = shape; // reveal initially
         cell.addEventListener('click', handleClick);
         board.appendChild(cell);
     });
+
+    // hide shapes after 2 seconds so the player can memorize them
+    setTimeout(() => {
+        document.querySelectorAll('.cell').forEach(c => {
+            c.textContent = '';
+        });
+        lockBoard = false;
+    }, 2000);
 }
 
 function handleClick(event) {


### PR DESCRIPTION
## Summary
- display the shapes for two seconds at the start of the memory game
- enlarge memory game cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b750f9d0c8324926353f374435853