### PR TITLE
Add 5-second win sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ The repository also includes a simple matching game. Open `memory.html` in a bro
 - A 2 x 3 grid of hidden shapes is presented.
 - Click on two cells to reveal their shapes.
 - If the shapes match they disappear; otherwise they are hidden again after a short delay.
+- When all matches are found, a star appears and a short celebratory sound plays for about five seconds.
 

--- a/memory.js
+++ b/memory.js
@@ -15,11 +15,15 @@ let matchedCount = 0;
 function playWinSound() {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
     const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
     oscillator.type = 'triangle';
     oscillator.frequency.setValueAtTime(440, ctx.currentTime);
-    oscillator.connect(ctx.destination);
+    gain.gain.setValueAtTime(0.2, ctx.currentTime);
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
     oscillator.start();
-    setTimeout(() => oscillator.stop(), 300);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 5);
+    oscillator.stop(ctx.currentTime + 5);
 }
 
 function celebrate() {


### PR DESCRIPTION
## Summary
- extend the win sound in the memory game to last ~5 seconds
- document the celebratory sound in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68649e165b688324845199862b5e313e